### PR TITLE
Add `minio` rock and tests

### DIFF
--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -76,5 +76,5 @@ parts:
 
       # Create default dir for minio backend
       mkdir $CRAFT_PART_INSTALL/data
-      chown 584792:584792 $CRAFT_PART_INSTALL/data
+      chown 584792:users $CRAFT_PART_INSTALL/data
       chmod 755 $CRAFT_PART_INSTALL/data

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -12,7 +12,7 @@ platforms:
 
 services:
   minio:
-    override: replace
+    override: merge
     summary: "minio service"
     startup: enabled
     command: "docker-entrypoint.sh minio [ ]"

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -18,6 +18,8 @@ services:
     command: "docker-entrypoint.sh minio [ ]"
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
+entrypoint-service: minio
+
 
 parts:
   security-team-requirement:

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -10,6 +10,7 @@ run-user: _daemon_
 platforms:
   amd64:
 
+entrypoint-service: minio    
 services:
   minio:
     override: replace

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -54,7 +54,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/licenses
       mkdir -p $CRAFT_PART_INSTALL/licenses
 
-      cp -fr dockerscripts/* $CRAFT_PART_INSTALL/usr/bin/
+      cp -fr dockerscripts/* $CRAFT_PART_INSTALL/bin/
       cp CREDITS $CRAFT_PART_INSTALL/licenses/CREDITS
       cp LICENSE $CRAFT_PART_INSTALL/licenses/LICENSE
 

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -50,28 +50,28 @@ parts:
     override-build: |
       set -xe
 
-      mkdir -p $CRAFT_PART_INSTALL/bin
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
       mkdir -p $CRAFT_PART_INSTALL/licenses
       mkdir -p $CRAFT_PART_INSTALL/licenses
 
-      cp -fr dockerscripts/* $CRAFT_PART_INSTALL/bin/
+      cp -fr dockerscripts/* $CRAFT_PART_INSTALL/usr/bin/
       cp CREDITS $CRAFT_PART_INSTALL/licenses/CREDITS
       cp LICENSE $CRAFT_PART_INSTALL/licenses/LICENSE
 
-      wget -q -O $CRAFT_PART_INSTALL/bin/minio https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}
-      wget -q -O $CRAFT_PART_INSTALL/bin/minio.sha256sum https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.sha256sum
-      wget -q -O $CRAFT_PART_INSTALL/bin/minio.minisig https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.minisig
+      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}
+      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio.sha256sum https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.sha256sum
+      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio.minisig https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.minisig
       
-      chmod +x $CRAFT_PART_INSTALL/bin/minio
-      chmod +x $CRAFT_PART_INSTALL/bin/docker-entrypoint.sh
-      chmod +x $CRAFT_PART_INSTALL/bin/verify-minio.sh
+      chmod +x $CRAFT_PART_INSTALL/usr/bin/minio
+      chmod +x $CRAFT_PART_INSTALL/usr/bin/docker-entrypoint.sh
+      chmod +x $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
       
       curl -O http://ftp.de.debian.org/debian/pool/main/m/minisign/minisign_0.11-1_amd64.deb
       apt-get install -y ./minisign_0.11-1_amd64.deb
 
-      sed -i 's|/usr/bin|$CRAFT_PART_INSTALL/bin|g' $CRAFT_PART_INSTALL/bin/verify-minio.sh
+      sed -i 's|/usr/bin|$CRAFT_PART_INSTALL/usr/bin|g' $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
 
-      $CRAFT_PART_INSTALL/bin/verify-minio.sh
+      $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
 
       # Create default dir for minio backend
       mkdir $CRAFT_PART_INSTALL/data

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -58,20 +58,20 @@ parts:
       cp CREDITS $CRAFT_PART_INSTALL/licenses/CREDITS
       cp LICENSE $CRAFT_PART_INSTALL/licenses/LICENSE
 
-      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}
-      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio.sha256sum https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.sha256sum
-      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio.minisig https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.minisig
+      wget -q -O $CRAFT_PART_INSTALL/bin/minio https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}
+      wget -q -O $CRAFT_PART_INSTALL/bin/minio.sha256sum https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.sha256sum
+      wget -q -O $CRAFT_PART_INSTALL/bin/minio.minisig https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.minisig
       
-      chmod +x $CRAFT_PART_INSTALL/usr/bin/minio
-      chmod +x $CRAFT_PART_INSTALL/usr/bin/docker-entrypoint.sh
-      chmod +x $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
+      chmod +x $CRAFT_PART_INSTALL/bin/minio
+      chmod +x $CRAFT_PART_INSTALL/bin/docker-entrypoint.sh
+      chmod +x $CRAFT_PART_INSTALL/bin/verify-minio.sh
       
       curl -O http://ftp.de.debian.org/debian/pool/main/m/minisign/minisign_0.11-1_amd64.deb
       apt-get install -y ./minisign_0.11-1_amd64.deb
 
-      sed -i 's|/usr/bin|$CRAFT_PART_INSTALL/usr/bin|g' $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
+      sed -i 's|/usr/bin|$CRAFT_PART_INSTALL/bin|g' $CRAFT_PART_INSTALL/bin/verify-minio.sh
 
-      $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
+      $CRAFT_PART_INSTALL/bin/verify-minio.sh
 
       # Create default dir for minio backend
       mkdir $CRAFT_PART_INSTALL/data

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -3,7 +3,7 @@ name: minio
 summary: MinIO is a High Performance Object Storage, API compatible with Amazon S3 cloud storage service.
 description: |
   MinIO object storage is fundamentally different. Designed for performance and the S3 API, it is 100% open-source. MinIO is ideal for large, private cloud environments with stringent security requirements and delivers mission-critical availability across a diverse range of workloads.
-version: 21.09.03
+version: ckf-1.9
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -10,7 +10,6 @@ run-user: _daemon_
 platforms:
   amd64:
 
-entrypoint-service: minio    
 services:
   minio:
     override: replace
@@ -19,6 +18,7 @@ services:
     command: "docker-entrypoint.sh minio [ ]"
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
+entrypoint-service: minio    
 
 parts:
   security-team-requirement:

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -12,7 +12,7 @@ platforms:
 
 services:
   minio:
-    override: merge
+    override: replace
     summary: "minio service"
     startup: enabled
     command: "docker-entrypoint.sh minio [ ]"

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -18,7 +18,6 @@ services:
     command: "docker-entrypoint.sh minio [ ]"
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
-entrypoint-service: minio    
 
 parts:
   security-team-requirement:

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -50,7 +50,7 @@ parts:
     override-build: |
       set -xe
 
-      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      mkdir -p $CRAFT_PART_INSTALL/bin
       mkdir -p $CRAFT_PART_INSTALL/licenses
       mkdir -p $CRAFT_PART_INSTALL/licenses
 

--- a/minio/tests/test_rock.py
+++ b/minio/tests/test_rock.py
@@ -25,12 +25,50 @@ def test_rock():
             "exec",
             "ls",
             "-la",
-            "/third_party/mariadb-connector-c",
+            "/usr/bin/minio"
         ],
         check=True,
     )
 
     subprocess.run(
-        ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/minio"],
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/usr/bin/docker-entrypoint.sh"
+        ],
         check=True,
     )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/licenses/CREDITS"
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/licenses/LICENSE"
+        ],
+        check=True,
+    )
+    

--- a/minio/tests/test_rock.py
+++ b/minio/tests/test_rock.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/third_party/mariadb-connector-c",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/bin/minio"],
+        check=True,
+    )

--- a/minio/tests/test_rock.py
+++ b/minio/tests/test_rock.py
@@ -21,11 +21,11 @@ def test_rock():
             "docker",
             "run",
             "--rm",
+            "--entrypoint",
+            "/bin/bash",
             LOCAL_ROCK_IMAGE,
-            "exec",
-            "ls",
-            "-la",
-            "/usr/bin/minio"
+            "-c",
+            "ls -la /usr/bin/minio"
         ],
         check=True,
     )
@@ -35,11 +35,25 @@ def test_rock():
             "docker",
             "run",
             "--rm",
+            "--entrypoint",
+            "/bin/bash",
             LOCAL_ROCK_IMAGE,
-            "exec",
-            "ls",
-            "-la",
-            "/usr/bin/docker-entrypoint.sh"
+            "-c",
+            "ls -la /usr/bin/docker-entrypoint.sh"
+        ],
+        check=True,
+    )
+    
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /licenses/CREDITS"
         ],
         check=True,
     )
@@ -49,25 +63,11 @@ def test_rock():
             "docker",
             "run",
             "--rm",
+            "--entrypoint",
+            "/bin/bash",
             LOCAL_ROCK_IMAGE,
-            "exec",
-            "ls",
-            "-la",
-            "/licenses/CREDITS"
-        ],
-        check=True,
-    )
-
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            LOCAL_ROCK_IMAGE,
-            "exec",
-            "ls",
-            "-la",
-            "/licenses/LICENSE"
+            "-c",
+            "ls -la /licenses/LICENSE"
         ],
         check=True,
     )

--- a/minio/tox.ini
+++ b/minio/tox.ini
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *

--- a/minio/tox.ini
+++ b/minio/tox.ini
@@ -1,0 +1,53 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, unit, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/mlmd-operator.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."

--- a/minio/tox.ini
+++ b/minio/tox.ini
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,7 +16,6 @@ services:
     summary: "minio service"
     startup: enabled
     command: "docker-entrypoint.sh minio [ ]"
-    user: ubuntu
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
 entrypoint-service: minio    
@@ -74,15 +73,7 @@ parts:
 
       $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
 
-  non-root-user:
-    plugin: nil
-    after: [ minio ]
-    overlay-script: |
-      # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
-      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
-    override-prime: |
-      craftctl default
-      chown 584792:584792 ${CRAFT_PART_INSTALL}/data
-      chmod 755 ${CRAFT_PART_INSTALL}/data
-      
+      # Create default dir for minio backend
+      mkdir /data
+      chown 584792:584792 $CRAFT_PART_INSTALL/data
+      chmod 755 $CRAFT_PART_INSTALL/data

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,7 @@ services:
   minio:
     override: replace
     summary: "minio service"
-    startup: enabled
+    startup: disabled
     command: "docker-entrypoint.sh minio [ ]"
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,7 +18,7 @@ services:
     command: "docker-entrypoint.sh [ minio ]"
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
-entrypoint-service: lgbserver    
+entrypoint-service: minio    
 
 parts:
   security-team-requirement:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -81,4 +81,7 @@ parts:
       # Create a user in the $CRAFT_OVERLAY chroot
       groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
       useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
+    override-prime: |
+      craftctl default
+      chown -R ubuntu:users data
       

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -76,7 +76,7 @@ parts:
 
   non-root-user:
     plugin: nil
-    after: [ otelcol ]
+    after: [ minio ]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
       groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,6 +16,7 @@ services:
     summary: "minio service"
     startup: enabled
     command: "docker-entrypoint.sh minio [ ]"
+    user: ubuntu
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
 entrypoint-service: minio    
@@ -72,5 +73,12 @@ parts:
       sed -i 's|/usr/bin|$CRAFT_PART_INSTALL/usr/bin|g' $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
 
       $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
-      
+
+  non-root-user:
+    plugin: nil
+    after: [ otelcol ]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
       

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,6 +18,7 @@ services:
     command: "docker-entrypoint.sh minio [ ]"
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
+entrypoint-service: minio    
 
 parts:
   security-team-requirement:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,6 +16,9 @@ services:
     summary: "minio service"
     startup: enabled
     command: "docker-entrypoint.sh [ minio ]"
+    environment:
+      MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
+entrypoint-service: lgbserver    
 
 parts:
   security-team-requirement:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -83,5 +83,6 @@ parts:
       useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
     override-prime: |
       craftctl default
-      chown -R ubuntu:users data
+      chown 584792:584792 ${CRAFT_PART_INSTALL}/data
+      chmod 755 ${CRAFT_PART_INSTALL}/data
       

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -15,10 +15,9 @@ services:
     override: replace
     summary: "minio service"
     startup: enabled
-    command: "docker-entrypoint.sh [ minio ]"
+    command: "docker-entrypoint.sh minio [ ]"
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
-entrypoint-service: minio    
 
 parts:
   security-team-requirement:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,9 +7,6 @@ version: 21.09.03
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
-environment: 
-  RELEASE: "RELEASE.2021-09-03T03-56-13Z"
-  TARGETARCH: "linux-amd64"
 platforms:
   amd64:
 
@@ -18,7 +15,6 @@ services:
     override: replace
     summary: "minio service"
     startup: enabled
-    user: appuser
     command: "docker-entrypoint.sh [ minio ]"
 
 parts:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,7 @@ services:
   minio:
     override: replace
     summary: "minio service"
-    startup: disabled
+    startup: enabled
     command: "docker-entrypoint.sh minio [ ]"
     environment:
       MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -74,6 +74,6 @@ parts:
       $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
 
       # Create default dir for minio backend
-      mkdir /data
+      mkdir $CRAFT_PART_INSTALL/data
       chown 584792:584792 $CRAFT_PART_INSTALL/data
       chmod 755 $CRAFT_PART_INSTALL/data

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,77 @@
+# Based on: https://github.com/minio/minio/blob/RELEASE.2021-09-03T03-56-13Z/Dockerfile.release
+name: minio
+summary: MinIO is a High Performance Object Storage, API compatible with Amazon S3 cloud storage service.
+description: |
+  MinIO object storage is fundamentally different. Designed for performance and the S3 API, it is 100% open-source. MinIO is ideal for large, private cloud environments with stringent security requirements and delivers mission-critical availability across a diverse range of workloads.
+version: 21.09.03
+license: Apache-2.0
+base: ubuntu@22.04
+run-user: _daemon_
+environment: 
+  RELEASE: "RELEASE.2021-09-03T03-56-13Z"
+  TARGETARCH: "linux-amd64"
+platforms:
+  amd64:
+
+services:
+  minio:
+    override: replace
+    summary: "minio service"
+    startup: enabled
+    user: appuser
+    command: "docker-entrypoint.sh [ minio ]"
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > \
+       ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  minio:
+    plugin: nil
+    source-type: git    
+    source: https://github.com/minio/minio
+    source-depth: 1
+    source-tag: RELEASE.2021-09-03T03-56-13Z
+    build-environment:
+      - RELEASE: RELEASE.2021-09-03T03-56-13Z
+      - TARGETARCH: amd64
+    build-packages:
+      - wget
+      - ca-certificates
+      - passwd
+      - util-linux
+      - iproute2
+      - iputils-ping
+      - bash
+      - rpm
+    override-build: |
+      set -xe
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      mkdir -p $CRAFT_PART_INSTALL/licenses
+      mkdir -p $CRAFT_PART_INSTALL/licenses
+
+      cp -fr dockerscripts/* $CRAFT_PART_INSTALL/usr/bin/
+      cp CREDITS $CRAFT_PART_INSTALL/licenses/CREDITS
+      cp LICENSE $CRAFT_PART_INSTALL/licenses/LICENSE
+
+      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}
+      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio.sha256sum https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.sha256sum
+      wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio.minisig https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.minisig
+      
+      chmod +x $CRAFT_PART_INSTALL/usr/bin/minio
+      chmod +x $CRAFT_PART_INSTALL/usr/bin/docker-entrypoint.sh
+      chmod +x $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
+      
+      curl -O http://ftp.de.debian.org/debian/pool/main/m/minisign/minisign_0.11-1_amd64.deb
+      apt-get install -y ./minisign_0.11-1_amd64.deb
+
+      sed -i 's|/usr/bin|$CRAFT_PART_INSTALL/usr/bin|g' $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
+
+      $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
+      
+      


### PR DESCRIPTION
### Description
---
* Add rockcraft.yaml
* Add tests
* Add tox.ini

Logs from tests
---
`juju status` after all tests are passed:
```
Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.1    unsupported  13:00:48Z

App                Version                       Status   Scale  Charm              Channel        Rev  Address         Exposed  Message
grafana-agent-k8s  0.32.1                        blocked      1  grafana-agent-k8s  latest/stable   45  10.152.183.143  no       grafana-dashboards-provider: off, grafana-cloud-config: off
minio              vyurchenko581/minio:21.09.03  active       1  minio                               0  10.152.183.17   no       

Unit                  Workload  Agent  Address      Ports          Message
grafana-agent-k8s/0*  blocked   idle   10.1.172.35                 grafana-dashboards-provider: off, grafana-cloud-config: off
minio/0*              active    idle   10.1.172.11  9000-9001/TCP  
```

Logs of passed integration tests `tox -vve integration -- --model kubeflow --keep-models`:
```
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.9.21, pytest-8.3.4, pluggy-1.5.0 -- /home/ubuntu/minio-operator/.tox/integration/bin/python
cachedir: .tox/integration/.pytest_cache
rootdir: /home/ubuntu/minio-operator
configfile: pyproject.toml
plugins: anyio-4.5.2, asyncio-0.21.2, operator-0.38.0
asyncio: mode=auto
collected 7 items                                                                                                                                                                                              

tests/integration/test_charm.py::test_build_and_deploy 
------------------------------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:766 Connecting to existing model microk8s-localhost:kubeflow on unspecified cloud
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:583 Using tmp_path: /home/ubuntu/minio-operator/.tox/integration/tmp/pytest/kubeflow0
INFO     pytest_operator.plugin:plugin.py:1139 Building charm minio
INFO     pytest_operator.plugin:plugin.py:1144 Built charm minio in 55.37s
INFO     test_charm:test_charm.py:36 Built charm /home/ubuntu/minio-operator/.tox/integration/tmp/pytest/kubeflow0/charms/minio_ubuntu-20.04-amd64.charm
INFO     juju.model:model.py:2284 Deploying local:kubernetes/minio-0
INFO     juju.model:model.py:3211 Waiting for model:
  minio/0 [allocating] waiting: installing agent
INFO     juju.model:model.py:3211 Waiting for model:
  minio/0 [allocating] waiting: installing agent
INFO     juju.model:model.py:3211 Waiting for model:
  minio/0 [allocating] waiting: agent initialising
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:78 deploying grafana-agent-k8s from latest/stable channel
INFO     juju.model:model.py:2284 Deploying ch:amd64/jammy/grafana-agent-k8s-45
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:82 Adding relation: minio:grafana-dashboard and grafana-agent-k8s:grafana-dashboards-consumer
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:95 Adding relation: minio:metrics-endpoint and grafana-agent-k8s:metrics-endpoint
INFO     juju.model:model.py:3211 Waiting for model:
  grafana-agent-k8s/0 [allocating] waiting: installing agent
INFO     juju.model:model.py:3211 Waiting for model:
  grafana-agent-k8s/0 [idle] waiting: agent initialising
INFO     juju.model:model.py:3211 Waiting for model:
  grafana-agent-k8s/0 [idle] blocked: grafana-dashboards-provider: off, grafana-cloud-config: off
INFO     juju.model:model.py:3211 Waiting for model:
  grafana-agent-k8s/0 [idle] blocked: grafana-dashboards-provider: off, grafana-cloud-config: off
PASSED
tests/integration/test_charm.py::test_metrics_enpoint 
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:229 found relations [<Relation id=2 grafana-agent-k8s:metrics-endpoint minio:metrics-endpoint>] for minio:metrics-endpoint
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:375 running cmd `relation-get --format=yaml -r 2 --app - minio` on unit minio/0
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:452 found endpoints: {'*:9000/minio/v2/metrics/cluster'}
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:375 running cmd `curl -m 5 -sS localhost:12345/agent/api/v1/metrics/targets` on unit grafana-agent-k8s/0
PASSED
tests/integration/test_charm.py::test_alert_rules 
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
INFO     test_charm:test_charm.py:68 found alert_rules: {'KubeflowServiceIsNotStable', 'KubeflowServiceDown'}
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:229 found relations [<Relation id=2 grafana-agent-k8s:metrics-endpoint minio:metrics-endpoint>] for minio:metrics-endpoint
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:375 running cmd `relation-get --format=yaml -r 2 --app - minio` on unit minio/0
PASSED
tests/integration/test_charm.py::test_grafana_dashboards 
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
INFO     test_charm:test_charm.py:76 found dashboards: {'minio-overview_rev13.json'}
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:229 found relations [<Relation id=1 grafana-agent-k8s:grafana-dashboards-consumer minio:grafana-dashboard>] for minio:grafana-dashboard
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:375 running cmd `relation-get --format=yaml -r 1 --app - minio` on unit minio/0
INFO     charmed_kubeflow_chisme.testing.cos_integration:cos_integration.py:375 running cmd `cat metadata.yaml` on unit minio/0
PASSED
tests/integration/test_charm.py::test_connect_client_to_server 
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
INFO     test_charm:test_charm.py:152 Test attempting to connect to minio using mc client (attempt 1)
PASSED
tests/integration/test_charm.py::test_connect_to_console 
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
INFO     test_charm:test_charm.py:178 ops_test.model_name = kubeflow
PASSED
tests/integration/test_charm.py::test_refresh_credentials 
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
INFO     test_charm:test_charm.py:226 Test attempting to connect to minio using mc client (attempt 1)
INFO     test_charm:test_charm.py:226 Test attempting to connect to minio using mc client (attempt 2)
INFO     test_charm:test_charm.py:226 Test attempting to connect to minio using mc client (attempt 3)
INFO     test_charm:test_charm.py:226 Test attempting to connect to minio using mc client (attempt 4)
PASSED
---------------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:903 Model status:

Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.1    unsupported  12:59:00Z

App                Version                       Status   Scale  Charm              Channel        Rev  Address         Exposed  Message
grafana-agent-k8s  0.32.1                        blocked      1  grafana-agent-k8s  latest/stable   45  10.152.183.143  no       grafana-dashboards-provider: off, grafana-cloud-config: off
minio              vyurchenko581/minio:21.09.03  active       1  minio                               0  10.152.183.17   no       

Unit                  Workload  Agent  Address      Ports          Message
grafana-agent-k8s/0*  blocked   idle   10.1.172.35                 grafana-dashboards-provider: off, grafana-cloud-config: off
minio/0*              active    idle   10.1.172.11  9000-9001/TCP  

INFO     pytest_operator.plugin:plugin.py:909 Juju error logs:


INFO     pytest_operator.plugin:plugin.py:991 Forgetting model main...


======================================================================================== 7 passed in 324.74s (0:05:24) =========================================================================================
integration: 347540 I exit 0 (326.04 seconds) /home/ubuntu/minio-operator> pytest -v --tb native --asyncio-mode=auto /home/ubuntu/minio-operator/tests/integration --log-cli-level=INFO -s --model kubeflow --keep-models pid=583885 [tox/execute/api.py:286]
  integration: OK (346.85=setup[20.81]+cmd[326.04] seconds)
  congratulations :) (347.09 seconds)
```