### PR TITLE
fix: use root to avoid PVC permission issues

### DIFF
--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -6,7 +6,6 @@ description: |
 version: ckf-1.10
 license: Apache-2.0
 base: ubuntu@22.04
-run-user: _daemon_
 platforms:
   amd64:
 
@@ -17,7 +16,7 @@ services:
     startup: enabled
     command: "docker-entrypoint.sh minio [ ]"
     environment:
-      MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"     
+      MINIO_UPDATE_MINISIGN_PUBKEY: "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"
 entrypoint-service: minio
 
 
@@ -32,7 +31,7 @@ parts:
 
   minio:
     plugin: nil
-    source-type: git    
+    source-type: git
     source: https://github.com/minio/minio
     source-depth: 1
     source-tag: RELEASE.2021-09-03T03-56-13Z
@@ -62,19 +61,14 @@ parts:
       wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}
       wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio.sha256sum https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.sha256sum
       wget -q -O $CRAFT_PART_INSTALL/usr/bin/minio.minisig https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.minisig
-      
+
       chmod +x $CRAFT_PART_INSTALL/usr/bin/minio
       chmod +x $CRAFT_PART_INSTALL/usr/bin/docker-entrypoint.sh
       chmod +x $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
-      
+
       curl -O http://ftp.de.debian.org/debian/pool/main/m/minisign/minisign_0.11-1_amd64.deb
       apt-get install -y ./minisign_0.11-1_amd64.deb
 
       sed -i 's|/usr/bin|$CRAFT_PART_INSTALL/usr/bin|g' $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
 
       $CRAFT_PART_INSTALL/usr/bin/verify-minio.sh
-
-      # Create default dir for minio backend
-      mkdir $CRAFT_PART_INSTALL/data
-      chown 584792:users $CRAFT_PART_INSTALL/data
-      chmod 755 $CRAFT_PART_INSTALL/data


### PR DESCRIPTION
Closes https://github.com/canonical/charmed-kubeflow-uats/issues/163

