### PR TITLE
fix: Move ca-certificates to overlay-packages

### DIFF
--- a/minio/rock-ci-metadata.yaml
+++ b/minio/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/minio-operator.git
+
+    replace-image:
+      - file: ./metadata.yaml
+        path: resources.oci-image.upstream-source

--- a/minio/rockcraft.yaml
+++ b/minio/rockcraft.yaml
@@ -40,13 +40,17 @@ parts:
       - TARGETARCH: amd64
     build-packages:
       - wget
-      - ca-certificates
       - passwd
       - util-linux
       - iproute2
       - iputils-ping
       - bash
       - rpm
+    overlay-packages:
+      # NOTE: "ca-certificates" installed among "overlay-packages" instead of
+      # "stage-packages" as a workaround to this issue:
+      # https://github.com/canonical/rockcraft/issues/334
+      - ca-certificates
     override-build: |
       set -xe
 


### PR DESCRIPTION
## Summary
This PR updates the `ca-certificates` by moving the package installation to `overlay` packages. This is a [known issue in rockcraft](https://github.com/canonical/rockcraft/issues/334).

We also add a `rock-ci-metadata.yaml` to do the rock integration.

Closes https://github.com/canonical/pipelines-rocks/issues/314